### PR TITLE
#24 markers aren't cleared when DevMarkerChart changes DataSource

### DIFF
--- a/src/DynamicDataDisplay.Markers/DevMarkerChart.cs
+++ b/src/DynamicDataDisplay.Markers/DevMarkerChart.cs
@@ -34,27 +34,22 @@ namespace DynamicDataDisplay.Charts.Markers
 			DrawAllMarkers(false);
 		}
 
-		#region DataSource
+        #region DataSource
 
-		protected override void OnDataSourceChanged(PointDataSourceBase prevSource, PointDataSourceBase currSource)
-		{
-			base.OnDataSourceChanged(prevSource, currSource);
+        protected override void OnDataSourceChanged(PointDataSourceBase prevSource, PointDataSourceBase currSource)
+        {
+            // Clear any existing children before redrawing collection
+            CurrentItemsPanel?.Children.Clear();
+            if (currSource != null)
+            {
+                MakeStandartPredictions(currSource);
+                DrawAllMarkers(true);
+            }
 
-			if (currSource != null)
-			{
-				MakeStandartPredictions(currSource);
-				DrawAllMarkers(true);
-			}
-			else
-			{
-				// todo clear
-			}
+            base.OnDataSourceChanged(prevSource, currSource);
+        }
 
-			// this is for PieChart in legend.
-			RaiseDataSourceChanged(prevSource, currSource);
-		}
-
-		private void MakeStandartPredictions(PointDataSourceBase currSource)
+        private void MakeStandartPredictions(PointDataSourceBase currSource)
 		{
 			Type dataType = currSource.GetDataType() as Type;
 			if (dataType != null)

--- a/src/DynamicDataDisplay.Samples/App.xaml
+++ b/src/DynamicDataDisplay.Samples/App.xaml
@@ -51,7 +51,10 @@
                 <m:Demonstration Description="Infinite Timeline Chart" Uri="/Demos/Custom/InfiniteTimelineChartTest.xaml"/>
                 <m:Demonstration Description="Mouse Navigation Switching" Uri="/Demos/Custom/MouseNaviationSwitchingSample.xaml"/>
                 <m:Demonstration Description="WMS Maps" Uri="/Demos/Custom/WmsMaps.xaml"/>
-      </m:ReleaseInfo>
+            </m:ReleaseInfo>
+            <m:ReleaseInfo Version="Developer Testing">
+                <m:Demonstration Description="Changing the ItemsSource" Uri="/Demos/UserTests/TestSwitchingMarkersDataSource.xaml"/>
+            </m:ReleaseInfo>
         </m:SamplesCollection>
 
         <local:VersionToBrushConverter x:Key="versionConverter"/>

--- a/src/DynamicDataDisplay.Samples/Demos/UserTests/TestSwitchingMarkersDataSource.xaml
+++ b/src/DynamicDataDisplay.Samples/Demos/UserTests/TestSwitchingMarkersDataSource.xaml
@@ -1,0 +1,43 @@
+﻿<Page x:Class="DynamicDataDisplay.Samples.Demos.UserTest.TestSwitchingMarkersDataSource"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d3="http://research.microsoft.com/DynamicDataDisplay/1.0"
+	  xmlns:sys="clr-namespace:System.Windows;assembly=WindowsBase"
+	  Title="Different built-in markers">
+    <Grid>
+		<d3:ChartPlotter Name="plotter">
+			<d3:DevMarkerChart Name="chart1" LegendDescription="Cross">
+				<d3:CrossMarker MarkerWidth="10" MarkerHeight="10" MarkerStroke="Blue"/>
+			</d3:DevMarkerChart>
+			<d3:DevMarkerChart Name="chart2" LegendDescription="Ellipse">
+				<d3:EllipseMarker MarkerStroke="Green" MarkerFill="{x:Null}"/>
+			</d3:DevMarkerChart>
+			<d3:DevMarkerChart Name="chart3" LegendDescription="Plus">
+				<d3:PlusMarker MarkerStroke="Red"/>
+			</d3:DevMarkerChart>
+			<d3:DevMarkerChart Name="chart4" LegendDescription="Down triangle">
+				<d3:DownTriangleMarker MarkerFill="Orange" MarkerStroke="{x:Null}"/>
+			</d3:DevMarkerChart>
+			<d3:DevMarkerChart Name="chart5" LegendDescription="Up triangle">
+				<d3:UpTriangleMarker MarkerFill="Olive" MarkerStroke="{x:Null}"/>
+			</d3:DevMarkerChart>
+			<d3:DevMarkerChart Name="chart6" LegendDescription="Diamond">
+				<d3:DiamondMarker MarkerFill="Violet" MarkerStroke="{x:Null}"/>
+			</d3:DevMarkerChart>
+			<d3:DevMarkerChart Name="chart7" LegendDescription="Rectangle">
+				<d3:RectangleMarker MarkerFill="Chartreuse" MarkerStroke="{x:Null}"/>
+			</d3:DevMarkerChart>
+			<d3:DevMarkerChart Name="chart8" LegendDescription="Numbers">
+				<d3:NewLegend.SampleData>
+					<sys:Point X="0" Y="0.71"/>
+				</d3:NewLegend.SampleData>
+				
+				<d3:TemplateMarkerGenerator>
+					<DataTemplate>
+						<TextBlock Text="{Binding Y, StringFormat=F2}"/>
+					</DataTemplate>
+				</d3:TemplateMarkerGenerator>
+			</d3:DevMarkerChart>
+		</d3:ChartPlotter>
+	</Grid>
+</Page>

--- a/src/DynamicDataDisplay.Samples/Demos/UserTests/TestSwitchingMarkersDataSource.xaml.cs
+++ b/src/DynamicDataDisplay.Samples/Demos/UserTests/TestSwitchingMarkersDataSource.xaml.cs
@@ -1,0 +1,91 @@
+﻿using DynamicDataDisplay.Charts.Markers;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace DynamicDataDisplay.Samples.Demos.UserTest
+{ 
+    /// <summary>
+    /// Interaction logic for DifferentBuildInMarkersPage.xaml
+    /// </summary>
+    public partial class TestSwitchingMarkersDataSource : Page
+    {
+        private const int _maxCount = 50;
+        private const int _minCount = 2;
+        private int _count = 1;
+        private int _countDirection = 1;
+        private int _startTime;
+        private DispatcherTimer _timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(10) };
+        private List<DevMarkerChart> _charts = new List<DevMarkerChart>();
+
+        public TestSwitchingMarkersDataSource()
+        {
+            InitializeComponent();
+            Loaded += OnLoaded;
+            Unloaded += OnUnloaded;
+        }
+
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            _startTime = Environment.TickCount;
+
+            _charts.AddMany
+            ([
+                chart1,
+                chart2,
+                chart3,
+                chart4,
+                chart5,
+                chart6,
+                chart7,
+                chart8,
+            ]);
+
+            _timer.Tick += timer_Tick;
+            _timer.Start();
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            _timer.Tick -= timer_Tick;
+            _timer.Stop();
+        }
+
+        void timer_Tick(object sender, EventArgs e)
+        {
+            if (_count >= _maxCount)
+            {
+                _countDirection = -1;
+            }
+            else if (_count <= _minCount)
+            {
+                _countDirection = 1;
+            }
+            _count += _countDirection;
+
+            for (int i = 0; i < _charts.Count; i++)
+            {
+                _charts[i].ItemsSource = CreateCollection(i+1);
+            }
+        }
+
+        private ImmutableList<Point> CreateCollection(int dataSourceNumber)
+        {
+            int time = Environment.TickCount;
+
+            var points = new Point[_count];
+
+            for (int i = 0; i < _count; i++)
+            {
+                double x = i / (double)_count;
+                points[i] = new Point(x, 0.1 * dataSourceNumber + 0.06 * Math.Sin(10 * x + Math.Sqrt(dataSourceNumber + 1) * 0.0005 * (time - _startTime)));
+            }
+
+            return ImmutableList.Create(points);
+        }
+    }
+}

--- a/src/DynamicDataDisplay.Samples/Demos/UserTests/TestSwitchingMarkersDataSource.xaml.cs
+++ b/src/DynamicDataDisplay.Samples/Demos/UserTests/TestSwitchingMarkersDataSource.xaml.cs
@@ -13,12 +13,33 @@ namespace DynamicDataDisplay.Samples.Demos.UserTest
     /// </summary>
     public partial class TestSwitchingMarkersDataSource : Page
     {
+        /// <summary>
+        /// Maximum number of markers to display in a line
+        /// </summary>
         private const int _maxCount = 50;
+        /// <summary>
+        /// Minimum number of markers to display in a line
+        /// </summary>
         private const int _minCount = 2;
+        /// <summary>
+        /// Current number of markers to display in a line
+        /// </summary>
         private int _count = 1;
+        /// <summary>
+        /// Used to increase or decrease the number of markers
+        /// </summary>
         private int _countDirection = 1;
+        /// <summary>
+        /// Time we started in CPU ticks, used for getting a relative time
+        /// </summary>
         private int _startTime;
+        /// <summary>
+        /// Timer used to update the markers
+        /// </summary>
         private DispatcherTimer _timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(10) };
+        /// <summary>
+        /// A list of chart controls that we are updating
+        /// </summary>
         private List<DevMarkerChart> _charts = new List<DevMarkerChart>();
 
         public TestSwitchingMarkersDataSource()
@@ -28,13 +49,13 @@ namespace DynamicDataDisplay.Samples.Demos.UserTest
             Unloaded += OnUnloaded;
         }
 
-
+        /// <summary>
+        /// Called when the control is loaded
+        /// </summary>
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             _startTime = Environment.TickCount;
-
-            _charts.AddMany
-            ([
+            _charts.AddMany([
                 chart1,
                 chart2,
                 chart3,
@@ -42,20 +63,22 @@ namespace DynamicDataDisplay.Samples.Demos.UserTest
                 chart5,
                 chart6,
                 chart7,
-                chart8,
-            ]);
+                chart8]);
 
-            _timer.Tick += timer_Tick;
+            _timer.Tick += Timer_Tick;
             _timer.Start();
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
-            _timer.Tick -= timer_Tick;
+            _timer.Tick -= Timer_Tick;
             _timer.Stop();
         }
 
-        void timer_Tick(object sender, EventArgs e)
+        /// <summary>
+        /// Periodic chart updater
+        /// </summary>
+        private void Timer_Tick(object sender, EventArgs e)
         {
             if (_count >= _maxCount)
             {
@@ -73,6 +96,9 @@ namespace DynamicDataDisplay.Samples.Demos.UserTest
             }
         }
 
+        /// <summary>
+        /// Creates an immutable collection of points from the current time, and data source number
+        /// </summary>
         private ImmutableList<Point> CreateCollection(int dataSourceNumber)
         {
             int time = Environment.TickCount;

--- a/src/DynamicDataDisplay.Samples/DynamicDataDisplay.Samples.csproj
+++ b/src/DynamicDataDisplay.Samples/DynamicDataDisplay.Samples.csproj
@@ -36,6 +36,7 @@
     <EmbeddedResource Include="Demos\v03\Repressilator.txt" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
When the DataSource is changed on a DevMarkerChart the old points are now removed.